### PR TITLE
increase polymorphism, base HVariantF on VariantF

### DIFF
--- a/haskus-utils-variant/src/lib/Haskus/Utils/Variant.hs
+++ b/haskus-utils-variant/src/lib/Haskus/Utils/Variant.hs
@@ -978,23 +978,23 @@ traverseVariant_ f v = void (traverseVariant @c @a f' v)
 
 
 
-class ReduceVariant c r (b :: [*]) where
+class ReduceVariant c (b :: [*]) where
    reduceVariant' :: (forall a. c a => a -> r) -> Word -> Any -> r
 
-instance ReduceVariant c r '[] where
+instance ReduceVariant c '[] where
    {-# INLINABLE reduceVariant' #-}
    reduceVariant' _ = undefined
 
 instance
-   ( ReduceVariant c r xs
+   ( ReduceVariant c xs
    , c x
-   ) => ReduceVariant c r (x ': xs)
+   ) => ReduceVariant c (x ': xs)
    where
       {-# INLINABLE reduceVariant' #-}
       reduceVariant' f t v =
          case t of
             0 -> f (unsafeCoerce v :: x)
-            n -> reduceVariant' @c @r @xs f (n-1) v
+            n -> reduceVariant' @c @xs f (n-1) v
 
 -- | Reduce a variant to a single value by using a class function. You need to
 -- specify the constraints required by the modifying function.
@@ -1002,11 +1002,12 @@ instance
 -- Usage:
 --    reduceVariant @Show show v
 --
-reduceVariant :: forall c r (a :: [*]).
-   ( ReduceVariant c r a
-   ) => (forall x. c x => x -> r) -> V a  -> r
+reduceVariant :: forall c (a :: [*]) r.
+   ( ReduceVariant c a
+   ) => (forall x. c x => x -> r) -> V a -> r
 {-# INLINABLE reduceVariant #-}
-reduceVariant f (Variant t a) = reduceVariant' @c @r @a f t a
+reduceVariant f (Variant t a) = reduceVariant' @c @a f t a
+
 
 
 -----------------------------------------------------------


### PR DESCRIPTION
I found it inconvenient to have to specify the return type in the `reduceVariant` function, as in certain situations one might want a polymorphic return type, such as `forall m. Monad m => m XYZ`. I think it makes more sense to let the return type be universally quantified.    

I similarly changed some functions dealing with `VariantF`, which makes them more general.    

I also added some functionality to EGADT to make the `VF` pattern synonym easier to use. I think it wouldn't be much effort now to merge the new `:<!` with the previous `:<`. I'm trying to keep the constraints simple and avoid recursive definitions as much as possible, as the type-level lists should be traversed as few times as possible (it can really strain the constraint solver if we start accumulating large expressions arising from folding through a type-level lists).

P.S. I notice that the current implementation of `reduceVariant` is recursive. Would it make more sense to have something like

```haskell
class ReduceVariant c (as :: [Type]) where
  reduceVariant :: ( forall a. c a => a -> r ) -> V a -> r

instance ( forall x. (x :< xs) => c x ) => ReduceVariant c xs where
  reduceVariant f (Variant i a) = case someNatVal ( fromIntegral i ) of
    ( SomeNat ( _ :: Proxy i) ) -> f ( unsafeCoerce a :: Index i xs )
```
(This quantified constraint isn't right due to the way these are resolved, but I think you understand the spirit.)    
Similar comments apply to `BottomUp` (which could be renamed `ReduceVariantF`).

