### PR TITLE
GHC 9.0 compatibility

### DIFF
--- a/haskus-utils-data/src/lib/Haskus/Utils/HList.hs
+++ b/haskus-utils-data/src/lib/Haskus/Utils/HList.hs
@@ -212,8 +212,8 @@ instance HTuple '[] where
 
 instance HTuple '[a] where
    hToTuple (a `HCons` HNil)
-      = Unit a
-   hFromTuple (Unit a)
+      = Solo a
+   hFromTuple (Solo a)
       = a `HCons` HNil
 
 instance HTuple '[a,b] where

--- a/haskus-utils-data/src/lib/Haskus/Utils/Monad.hs
+++ b/haskus-utils-data/src/lib/Haskus/Utils/Monad.hs
@@ -36,10 +36,10 @@ class MonadIO m => MonadInIO m where
 
 instance MonadInIO IO where
    {-# INLINABLE liftWith #-}
-   liftWith = id
+   liftWith wth f = wth f
 
    {-# INLINABLE liftWith2 #-}
-   liftWith2 = id
+   liftWith2 wth f = wth f
 
 instance MonadInIO m => MonadInIO (StateT s m) where
    {-# INLINABLE liftWith #-}

--- a/haskus-utils-variant/src/lib/Haskus/Utils/ContFlow.hs
+++ b/haskus-utils-variant/src/lib/Haskus/Utils/ContFlow.hs
@@ -84,7 +84,7 @@ infixl 0 >::>
 -- | Bind a flow to a 1-tuple of continuations
 (>:-:>) :: ContFlow '[a] r -> (a -> r) -> r
 {-# INLINABLE (>:-:>) #-}
-(>:-:>) (ContFlow f) c = f (Unit c)
+(>:-:>) (ContFlow f) c = f (Solo c)
 
 infixl 0 >:-:>
 

--- a/haskus-utils-variant/src/lib/Haskus/Utils/EADT/TH.hs
+++ b/haskus-utils-variant/src/lib/Haskus/Utils/EADT/TH.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE CPP #-}
 
 -- | Template-Haskell helpers for EADTs
 module Haskus.Utils.EADT.TH
@@ -142,7 +143,11 @@ eadtPattern' consName patStr mEadtTy isInfix = do
             tyToTyList = AppT ListT (AppT (AppT ArrowT StarT) StarT)
 
             -- retreive functor var in "e"
+#if MIN_VERSION_base(4,15,0)
+            KindedTV e _ StarT = last tvs
+#else
             KindedTV e StarT = last tvs
+#endif
 
 
          -- make pattern type
@@ -150,7 +155,11 @@ eadtPattern' consName patStr mEadtTy isInfix = do
             xsName <- newName "xs"
             let
                xs = VarT xsName
+#if MIN_VERSION_base(4,15,0)
+               xsTy = KindedTV xsName SpecifiedSpec tyToTyList
+#else
                xsTy = KindedTV xsName tyToTyList
+#endif
             eadtXs <- [t| EADT $(return xs) |]
 
             prd <-  [t| $(return conTyp) :<: $(return xs) |]

--- a/haskus-utils-variant/src/lib/Haskus/Utils/Variant.hs
+++ b/haskus-utils-variant/src/lib/Haskus/Utils/Variant.hs
@@ -1263,21 +1263,21 @@ class ContVariant xs where
 
 instance ContVariant '[a] where
    {-# INLINABLE variantToCont #-}
-   variantToCont (Variant _ a) = ContFlow $ \(Unit f) ->
+   variantToCont (Variant _ a) = ContFlow $ \(Solo f) ->
       f (unsafeCoerce a)
 
    {-# INLINABLE variantToContM #-}
-   variantToContM act = ContFlow $ \(Unit f) -> do
+   variantToContM act = ContFlow $ \(Solo f) -> do
       Variant _ a <- act
       f (unsafeCoerce a)
 
    {-# INLINABLE contToVariant #-}
    contToVariant c = c >::>
-      Unit (toVariantAt @0)
+      Solo (toVariantAt @0)
 
    {-# INLINABLE contToVariantM #-}
    contToVariantM c = c >::>
-      Unit (return . toVariantAt @0)
+      Solo (return . toVariantAt @0)
 
 instance ContVariant '[a,b] where
    {-# INLINABLE variantToCont #-}


### PR DESCRIPTION
- Use  `Solo` instead of `Unit` in `Haskus.Utils.Tuple` and related modules.
- Adapt to lack of subsumption in `Haskus.Utils.Monad`.
- Handle specificities in TH in `Haskus.Utils.EADT.TH`.