### PR TITLE
Utils: support paths relative to .cabal file

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -22,3 +22,5 @@ packages:
 
 program-options
   ghc-options: -fhide-source-paths
+
+multi-repl: True

--- a/haskus-locale/src/lib/Haskus/Locale/Country.hs
+++ b/haskus-locale/src/lib/Haskus/Locale/Country.hs
@@ -20,7 +20,7 @@ import Haskus.Utils.Embed.ByteString
 -- | Raw country data taken from https://github.com/datasets/country-codes/
 -- (see https://datahub.io/core/country-codes)
 countryData :: LBS.ByteString
-countryData = LBS.fromStrict $(embedBSFilePrefix "haskus-locale" "src/data/country-codes.csv")
+countryData = LBS.fromStrict $(embedBSFile "src/data/country-codes.csv")
 
 -- | Country data
 countries :: Vector Country

--- a/haskus-system/src/lib/Haskus/System/PCI/MakeTable.hs
+++ b/haskus-system/src/lib/Haskus/System/PCI/MakeTable.hs
@@ -5,6 +5,7 @@ module Haskus.System.PCI.MakeTable
 where
 
 import Haskus.Utils.Flow
+import Haskus.Utils.Embed
 import Haskus.Binary.Bits
 
 import Language.Haskell.TH.Quote
@@ -19,7 +20,7 @@ import Data.Void
 type Parser = Parsec Void String
 
 pcis :: QuasiQuoter
-pcis = quoteFile $ QuasiQuoter
+pcis = quoteRelativeFile $ QuasiQuoter
    { quoteDec  = makeTable
    , quoteExp  = undefined
    , quotePat  = undefined

--- a/haskus-utils-compat/haskus-utils-compat.cabal
+++ b/haskus-utils-compat/haskus-utils-compat.cabal
@@ -1,22 +1,23 @@
+cabal-version:       2.4
 name:                haskus-utils-compat
 version:             1.1
 synopsis:            Compatibility modules with other external packages (ByteString, etc.)
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Sylvain Henry
 maintainer:          sylvain@haskus.fr
 homepage:            http://docs.haskus.org/
-copyright:           Sylvain Henry 2020
+copyright:           Sylvain Henry 2024
 category:            System
 build-type:          Simple
-cabal-version:       1.20
 
 description:
    Compatibility modules with other external packages (ByteString, etc.)
 
 source-repository head
   type: git
-  location: git://github.com/haskus/packages.git
+  location: https://github.com/haskus/packages
+  subdir: haskus-utils-compat
 
 library
   exposed-modules:
@@ -30,6 +31,7 @@ library
       ,  template-haskell          >= 2.10
       ,  haskus-binary
       ,  haskus-utils-data
+      ,  haskus-utils
       ,  directory
       ,  filepath
       ,  bytestring

--- a/haskus-utils-compat/src/lib/Haskus/Utils/Embed/ByteString.hs
+++ b/haskus-utils-compat/src/lib/Haskus/Utils/Embed/ByteString.hs
@@ -12,7 +12,6 @@ module Haskus.Utils.Embed.ByteString
    ( bufferToByteString
    , embedBS
    , embedBSFile
-   , embedBSFilePrefix
    , embedBSOneFileOf
    , embedBSDir
    , module Haskus.Memory.Embed
@@ -34,6 +33,7 @@ import Control.Arrow
 import Haskus.Memory.Buffer
 import Haskus.Memory.Embed
 import Haskus.Utils.Monad
+import Haskus.Utils.Embed
 
 ----------------------------------------------------------------------
 -- File embedding adapted from file-embed package (BSD3).
@@ -51,20 +51,11 @@ import Haskus.Utils.Monad
 -- > myFile :: Data.ByteString.ByteString
 -- > myFile = $(embedFile "dirName/fileName")
 embedBSFile :: FilePath -> Q Exp
-embedBSFile fp = do
-   qAddDependentFile fp
-   bs <- runIO $ BS.readFile fp
-   embedBS bs
-
-embedBSFilePrefix :: FilePath -> FilePath -> Q Exp
-embedBSFilePrefix prefix fp' = do
-   -- small hack because "stack build" and "stack repl" in the multi-package
-   -- project have different CWD
-   fp <- liftIO (doesFileExist fp') >>= \case
-            True  -> return fp'
-            False -> return (prefix </> fp')
-   embedBSFile fp
-
+embedBSFile rfp = do
+  fp <- qRelativeToCabalProjectPath rfp
+  qAddDependentFile fp
+  bs <- runIO $ BS.readFile fp
+  embedBS bs
 
 -- | Embed a single existing file in your source code
 -- out of list a list of paths supplied.

--- a/haskus-utils/haskus-utils.cabal
+++ b/haskus-utils/haskus-utils.cabal
@@ -1,22 +1,23 @@
+cabal-version:       2.4
 name:                haskus-utils
 version:             1.5
 synopsis:            Haskus utility modules
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Sylvain Henry
 maintainer:          sylvain@haskus.fr
-homepage:            http://docs.haskus.org/
-copyright:           Sylvain Henry 2018
+homepage:            https://haskus.org/
+copyright:           Sylvain Henry 2024
 category:            System
 build-type:          Simple
-cabal-version:       1.20
 
 description:
    Haskus utility modules.
 
 source-repository head
   type: git
-  location: git://github.com/haskus/haskus-utils.git
+  location: https://github.com/haskus/packages
+  subdir: haskus-utils
 
 library
   exposed-modules:
@@ -44,23 +45,28 @@ library
   other-modules:
 
   build-depends:       
-         base                      >= 4.9 && < 5
-      ,  haskus-utils-types        >= 1.3
-      ,  haskus-utils-data
-      ,  haskus-utils-variant      >= 2.4
-      ,  containers                >= 0.5
-      ,  list-t                    >= 0.4
-      ,  stm                       >= 2.4
-      ,  stm-containers            >= 1.1
-      ,  vector                    >= 0.11
-      ,  transformers              >= 0.4
-      ,  mtl                       >= 2.2
-      ,  template-haskell          >= 2.10
-      ,  hashable                  >= 1.2
-      ,  free
+        base                      >= 4.9 && < 5
+      , haskus-utils-types        >= 1.3
+      , haskus-utils-data
+      , haskus-utils-variant      >= 2.4
+      , containers                >= 0.5
+      , list-t                    >= 0.4
+      , stm                       >= 2.4
+      , stm-containers            >= 1.1
+      , vector                    >= 0.11
+      , transformers              >= 0.4
+      , mtl                       >= 2.2
+      , template-haskell          >= 2.10
+      , hashable                  >= 1.2
+      , free
+      , directory
+      , filepath
 
   ghc-options:          -Wall
   default-language:     Haskell2010
+  default-extensions:
+    LambdaCase
+    BlockArguments
   hs-source-dirs:       src/lib
 
 test-suite tests

--- a/haskus-web/src/lib/Haskus/Web/Files.hs
+++ b/haskus-web/src/lib/Haskus/Web/Files.hs
@@ -18,19 +18,19 @@ import Data.ByteString
 -- | Map (FileName,Contents)
 scriptFiles :: Map Text ByteString
 scriptFiles = Map.fromList
-   [("jquery.min.js"         ,$(embedBSFilePrefix "haskus-web" "src/scripts/jquery-3.2.1.min.js"))
-   ,("jquery-ui.min.js"      ,$(embedBSFilePrefix "haskus-web" "src/scripts/jquery-ui.min.js"))
-   ,("jquery-ui.js"          ,$(embedBSFilePrefix "haskus-web" "src/scripts/jquery-ui.js"))
-   ,("jquery-ui-touch.min.js",$(embedBSFilePrefix "haskus-web" "src/scripts/jquery.ui.touch-punch.min.js"))
-   ,("jquery-ui-block.js"    ,$(embedBSFilePrefix "haskus-web" "src/scripts/jquery.blockUI.js"))
-   ,("jquery-imgload.min.js" ,$(embedBSFilePrefix "haskus-web" "src/scripts/imagesloaded.pkgd.min.js"))
-   ,("jquery-imgload.js"     ,$(embedBSFilePrefix "haskus-web" "src/scripts/imagesloaded.pkgd.js"))
-   ,("d3.js"                 ,$(embedBSFilePrefix "haskus-web" "src/scripts/d3.v5.js"))
-   ,("d3.min.js"             ,$(embedBSFilePrefix "haskus-web" "src/scripts/d3.v5.min.js"))
+   [("jquery.min.js"         ,$(embedBSFile "src/scripts/jquery-3.2.1.min.js"))
+   ,("jquery-ui.min.js"      ,$(embedBSFile "src/scripts/jquery-ui.min.js"))
+   ,("jquery-ui.js"          ,$(embedBSFile "src/scripts/jquery-ui.js"))
+   ,("jquery-ui-touch.min.js",$(embedBSFile "src/scripts/jquery.ui.touch-punch.min.js"))
+   ,("jquery-ui-block.js"    ,$(embedBSFile "src/scripts/jquery.blockUI.js"))
+   ,("jquery-imgload.min.js" ,$(embedBSFile "src/scripts/imagesloaded.pkgd.min.js"))
+   ,("jquery-imgload.js"     ,$(embedBSFile "src/scripts/imagesloaded.pkgd.js"))
+   ,("d3.js"                 ,$(embedBSFile "src/scripts/d3.v5.js"))
+   ,("d3.min.js"             ,$(embedBSFile "src/scripts/d3.v5.min.js"))
    ]
 
 -- | Map (FileName,Contents)
 cssFiles :: Map Text ByteString
 cssFiles = Map.fromList
-   [("jquery-ui.css"     ,$(embedBSFilePrefix "haskus-web" "src/css/jquery-ui.theme.css"))
+   [("jquery-ui.css"     ,$(embedBSFile "src/css/jquery-ui.theme.css"))
    ]


### PR DESCRIPTION
This is useful for file embedding or TH splices that use files.